### PR TITLE
Handle Production casing without unsupported helpers

### DIFF
--- a/.github/workflows/auto-alias-production.yml
+++ b/.github/workflows/auto-alias-production.yml
@@ -6,7 +6,13 @@ on:
 
 jobs:
   update-domain-aliases:
-    if: github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Production'
+    if: >
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment_status.environment &&
+      contains(
+        fromJSON('["production","Production"]'),
+        github.event.deployment_status.environment
+      )
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- replace the unsupported toLower helper in the auto-alias workflow with a case-insensitive array check for the deployment environment

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68dd71f8fa6c833395fbfd1a7eb271bb