### PR TITLE
Return gamification snapshot with note creation

### DIFF
--- a/client2/src/components/FloatingNotepad.jsx
+++ b/client2/src/components/FloatingNotepad.jsx
@@ -142,6 +142,11 @@ const FloatingNotepad = ({ title, book = null, initialContent = "", currentPage 
       });
       console.log('✅ Note saved successfully:', response.data);
 
+      const serverGamification = response.data?.gamification;
+      if (serverGamification) {
+        console.log('🎯 Server gamification snapshot received:', serverGamification);
+      }
+
       // Track gamification action for note creation (+15 points)
       if (trackAction) {
         try {
@@ -150,7 +155,7 @@ const FloatingNotepad = ({ title, book = null, initialContent = "", currentPage 
             note_id: response.data.id,
             page: currentPage,
             timestamp: new Date().toISOString()
-          });
+          }, { serverSnapshot: serverGamification });
           console.log('🎮 Gamification: note_created action tracked (+15 points)');
         } catch (trackError) {
           console.warn('⚠️ Failed to track note creation for gamification:', trackError);
@@ -158,7 +163,11 @@ const FloatingNotepad = ({ title, book = null, initialContent = "", currentPage 
         }
       }
 
-      showSnackbar({ message: "Note saved successfully! ✓", variant: "success" });
+      const snackbarMessage = serverGamification?.totalPoints != null
+        ? `Note saved successfully! ⭐ Total points: ${serverGamification.totalPoints}`
+        : "Note saved successfully! ✓";
+
+      showSnackbar({ message: snackbarMessage, variant: "success" });
       setContent("");
       setIsSaving(false);
     } catch (error) {

--- a/client2/src/pages/MD3NotesPage.jsx
+++ b/client2/src/pages/MD3NotesPage.jsx
@@ -197,6 +197,11 @@ const openAtLocation = (note) => {
       } else {
         const response = await API.post('/notes', noteData, { timeout: 30000 });
 
+        const serverGamification = response.data?.gamification;
+        if (serverGamification) {
+          console.log('🎯 Server gamification snapshot received:', serverGamification);
+        }
+
         // Track note creation for gamification
         try {
           await trackAction('note_created', {
@@ -204,15 +209,19 @@ const openAtLocation = (note) => {
             bookId: noteData.book_id,
             noteLength: noteData.content.length,
             hasTags: noteData.tags.length > 0
-          });
+          }, { serverSnapshot: serverGamification });
           console.log('✅ Note creation tracked - 15 points awarded');
         } catch (trackError) {
           console.error('Failed to track note creation:', trackError);
           // Don't fail note creation if tracking fails
         }
 
+        const successMessage = serverGamification?.totalPoints != null
+          ? `Note created successfully! ⭐ Total points: ${serverGamification.totalPoints}`
+          : 'Note created successfully! +15 points earned!';
+
         showSnackbar({
-          message: 'Note created successfully! +15 points earned!',
+          message: successMessage,
           variant: 'success'
         });
       }


### PR DESCRIPTION
## Summary
- add a reusable gamification snapshot helper for the notes API so note creation responses include the latest totals and level
- allow the gamification context to apply optional server-provided snapshots when tracking actions to prevent double counting
- surface the returned snapshot in the MD3 notes flows to update the snackbar messaging and stats after saves

## Testing
- pnpm --filter client2 lint *(fails: ESLint flat config still expects plugin objects in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee785346ac8333a4af55e70997173e