### PR TITLE
Add Jolman Press marketing page

### DIFF
--- a/client2/src/App.jsx
+++ b/client2/src/App.jsx
@@ -71,6 +71,7 @@ const SignUpPage = lazy(() => import('./pages/SignUpPage'));
 const DashboardPage = lazy(() => import('./pages/DashboardPage'));
 const ProgressPage = lazy(() => import('./pages/ProgressPage'));
 const AchievementsPage = lazy(() => import('./pages/AchievementsPage'));
+const JolmanPressPage = lazy(() => import('./pages/JolmanPressPage'));
 // Library Page wrapper (lazy-loaded)
 const LibraryPageWrapper = lazy(() =>
   import('./components/wrappers/LibraryPageWrapper').catch(err => {
@@ -293,6 +294,13 @@ const AppRoutes = () => {
         <ErrorBoundary fallbackComponent="contact" variant="full">
           <Suspense fallback={<AppLoadingSpinner message="Opening Contact…" />}>
             <ContactDialog />
+          </Suspense>
+        </ErrorBoundary>
+      } />
+      <Route path="/jolman-press" element={
+        <ErrorBoundary fallbackComponent="jolman-press" variant="full">
+          <Suspense fallback={<AppLoadingSpinner message="Loading Jolman Press..." />}>
+            <JolmanPressPage />
           </Suspense>
         </ErrorBoundary>
       } />

--- a/client2/src/pages/JolmanPressPage.css
+++ b/client2/src/pages/JolmanPressPage.css
@@ -1,0 +1,197 @@
+.jolman-page {
+  min-height: 100vh;
+  padding: 48px clamp(16px, 3vw, 56px) 80px;
+  background: radial-gradient(circle at 20% 20%, rgba(118, 101, 255, 0.12), transparent 36%),
+    radial-gradient(circle at 80% 0%, rgba(0, 184, 212, 0.14), transparent 32%),
+    linear-gradient(180deg, rgba(18, 18, 18, 0.04), rgba(18, 18, 18, 0.08));
+  color: var(--md-sys-color-on-surface, #1b1b1b);
+}
+
+.jolman-hero {
+  background: color-mix(in srgb, var(--md-sys-color-surface, #fff) 92%, var(--md-sys-color-primary, #6750a4));
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline-variant, #cac4d0) 80%, transparent);
+  border-radius: 28px;
+  padding: clamp(24px, 4vw, 48px);
+  box-shadow: 0 22px 50px rgba(0, 0, 0, 0.08);
+  max-width: 1040px;
+  margin: 0 auto 40px auto;
+  text-align: center;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--md-sys-color-primary, #6750a4) 12%, transparent);
+  color: var(--md-sys-color-primary, #6750a4);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.jolman-hero h1 {
+  margin: 14px 0 8px;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  color: var(--md-sys-color-primary, #6750a4);
+}
+
+.jolman-hero .subtitle {
+  font-size: 1.05rem;
+  max-width: 720px;
+  margin: 0 auto;
+  color: var(--md-sys-color-on-surface-variant, #49454f);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.pillars {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.pillar-card {
+  padding: 18px;
+  border-radius: 20px;
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline-variant, #cac4d0) 85%, transparent);
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: center;
+  background: var(--md-sys-color-surface, #ffffff);
+}
+
+.pillar-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--md-sys-color-primary, #6750a4) 12%, transparent);
+  color: var(--md-sys-color-primary, #6750a4);
+  font-size: 24px;
+}
+
+.pillar-content h2 {
+  margin: 0 0 6px;
+  font-size: 1.1rem;
+  color: var(--md-sys-color-on-surface, #1b1b1b);
+}
+
+.pillar-content p {
+  margin: 0;
+  color: var(--md-sys-color-on-surface-variant, #49454f);
+}
+
+.highlights {
+  max-width: 1040px;
+  margin: 44px auto;
+  padding: 24px 26px;
+  border-radius: 24px;
+  border: 1px dashed color-mix(in srgb, var(--md-sys-color-outline, #79747e) 60%, transparent);
+  background: color-mix(in srgb, var(--md-sys-color-surface-variant, #e7e0ec) 35%, transparent);
+}
+
+.highlights-header h3 {
+  margin: 0 0 8px;
+  font-size: 1.3rem;
+  color: var(--md-sys-color-on-surface, #1b1b1b);
+}
+
+.highlights-header p {
+  margin: 0;
+  color: var(--md-sys-color-on-surface-variant, #49454f);
+}
+
+.highlight-list {
+  list-style: none;
+  padding: 16px 0 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.highlight-list li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-items: center;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--md-sys-color-surface, #fff) 86%, var(--md-sys-color-primary-container, #eaddff));
+  color: var(--md-sys-color-on-surface, #1b1b1b);
+}
+
+.highlight-list .material-symbols-outlined {
+  color: var(--md-sys-color-primary, #6750a4);
+}
+
+.cta-card {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 24px 26px;
+  border-radius: 24px;
+  background: color-mix(in srgb, var(--md-sys-color-surface, #fff) 95%, var(--md-sys-color-secondary, #625b71));
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline-variant, #cac4d0) 90%, transparent);
+  display: grid;
+  gap: 12px;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+}
+
+.eyebrow {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--md-sys-color-secondary, #625b71);
+  font-weight: 700;
+  margin: 0 0 6px;
+}
+
+.cta-card h3 {
+  margin: 0;
+  color: var(--md-sys-color-on-surface, #1b1b1b);
+}
+
+.cta-copy {
+  margin: 6px 0 0;
+  color: var(--md-sys-color-on-surface-variant, #49454f);
+}
+
+.cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-start;
+}
+
+.cta-actions a {
+  text-decoration: none;
+}
+
+@media (max-width: 640px) {
+  .jolman-page {
+    padding: 32px 16px 64px;
+  }
+
+  .pillar-card {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+
+  .cta-card {
+    grid-template-columns: 1fr;
+  }
+}

--- a/client2/src/pages/JolmanPressPage.jsx
+++ b/client2/src/pages/JolmanPressPage.jsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import './JolmanPressPage.css';
+
+const JolmanPressPage = () => {
+  const navigate = useNavigate();
+
+  const pillars = [
+    {
+      icon: 'apartment',
+      title: 'Independent Studio',
+      description: 'Jolman Press builds ShelfQuest and companion tools with a focus on reader-centric design and AI-assisted workflows.'
+    },
+    {
+      icon: 'auto_awesome',
+      title: 'Material Design 3',
+      description: 'We rely on MD3 theming, motion, and accessibility guidance to deliver adaptive experiences across web and desktop.'
+    },
+    {
+      icon: 'psychology',
+      title: 'AI-Ready Foundation',
+      description: 'Data-driven recommendations, smart insights, and assistive features keep your reading goals on track.'
+    }
+  ];
+
+  const highlights = [
+    'Unified brand across ShelfQuest, library dashboards, and future companion apps',
+    'Deployment readiness checklists and release scorecards guide every launch',
+    'Performance-first code with offline support and secure authentication',
+    'Human-friendly documentation so partners understand how we build'
+  ];
+
+  return (
+    <div className="jolman-page">
+      <header className="jolman-hero" data-testid="jolman-hero">
+        <div className="badge">Studio Identity</div>
+        <h1>Jolman Press</h1>
+        <p className="subtitle">
+          The creative studio behind ShelfQuest and a growing suite of reading-forward applications.
+        </p>
+        <div className="hero-actions">
+          <button
+            type="button"
+            className="md3-button md3-button-filled"
+            onClick={() => navigate('/signup')}
+          >
+            <span className="material-symbols-outlined">rocket_launch</span>
+            Start with ShelfQuest
+          </button>
+          <button
+            type="button"
+            className="md3-button md3-button-outlined"
+            onClick={() => navigate('/login')}
+          >
+            <span className="material-symbols-outlined">login</span>
+            Already a member
+          </button>
+        </div>
+      </header>
+
+      <section className="pillars" aria-label="Jolman Press pillars">
+        {pillars.map(pillar => (
+          <article key={pillar.title} className="pillar-card md3-surface" aria-label={pillar.title}>
+            <div className="pillar-icon" aria-hidden="true">
+              <span className="material-symbols-outlined">{pillar.icon}</span>
+            </div>
+            <div className="pillar-content">
+              <h2>{pillar.title}</h2>
+              <p>{pillar.description}</p>
+            </div>
+          </article>
+        ))}
+      </section>
+
+      <section className="highlights" aria-label="How we build">
+        <div className="highlights-header">
+          <h3>How we build and ship</h3>
+          <p>
+            Every release follows our Deployment Readiness checklist and a one-page Release Readiness Scorecard to keep
+            engineering, design, and communications aligned.
+          </p>
+        </div>
+        <ul className="highlight-list">
+          {highlights.map(item => (
+            <li key={item}>
+              <span className="material-symbols-outlined" aria-hidden="true">check_circle</span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="cta-card md3-elevated" aria-label="Get in touch">
+        <div>
+          <p className="eyebrow">Partner with us</p>
+          <h3>Want to learn more about Jolman Press?</h3>
+          <p className="cta-copy">
+            We love collaborating on thoughtful reading tools. Reach out for product questions, partnerships, or to see how
+            ShelfQuest can accelerate your team.
+          </p>
+        </div>
+        <div className="cta-actions">
+          <a className="md3-button md3-button-tonal" href="mailto:hello@jolmanpress.com">
+            <span className="material-symbols-outlined">mail</span>
+            Email the studio
+          </a>
+          <button
+            type="button"
+            className="md3-button md3-button-text"
+            onClick={() => navigate('/')}
+          >
+            <span className="material-symbols-outlined">arrow_back</span>
+            Return home
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default JolmanPressPage;

--- a/client2/src/pages/NewLandingPage.jsx
+++ b/client2/src/pages/NewLandingPage.jsx
@@ -201,6 +201,8 @@ const NewLandingPage = () => {
           {' '}•{' '}
           <a href="/contact" className="footer-link">Contact Us</a>
           {' '}•{' '}
+          <a href="/jolman-press" className="footer-link">About Jolman Press</a>
+          {' '}•{' '}
           <a href="/legal/privacy-policy" className="footer-link">Privacy Policy</a>
           {' '}•{' '}
           <a href="/legal/terms-of-service" className="footer-link">Terms</a>


### PR DESCRIPTION
## Summary
- add a dedicated Jolman Press identity page that highlights the studio behind ShelfQuest using Material Design 3 styling
- register a public /jolman-press route with lazy loading and proper fallbacks
- link the new page from the landing footer for easy discovery

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ab7d0a5c83338f84bab4a3172347)