### PR TITLE
Normalize auth email handling and use secure routes

### DIFF
--- a/client2/src/components/ResetPassword.jsx
+++ b/client2/src/components/ResetPassword.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import environmentConfig from '../config/environment';
+import environmentConfig from '../config/environment.js';
 import './ResetPassword.css';
 
 /**

--- a/client2/src/contexts/AuthContext.jsx
+++ b/client2/src/contexts/AuthContext.jsx
@@ -414,7 +414,7 @@ export const AuthProvider = ({ children }) => {
       setLoading(true);
       setError(null);
       try {
-        const data = await makeApiCall('/auth/register', {
+        const data = await makeApiCall('/auth/secure/register', {
           method: 'POST',
           body: JSON.stringify({ email, password, name }),
         });
@@ -441,7 +441,7 @@ export const AuthProvider = ({ children }) => {
       setLoading(true);
       setError(null);
       try {
-        const data = await makeApiCall('/auth/login', {
+        const data = await makeApiCall('/auth/secure/login', {
           method: 'POST',
           body: JSON.stringify({ email, password }),
         });
@@ -562,7 +562,7 @@ export const AuthProvider = ({ children }) => {
     async (currentPassword, newPassword) => {
       setError(null);
       try {
-        await makeAuthenticatedApiCall('/auth/change-password', {
+        await makeAuthenticatedApiCall('/auth/secure/change-password', {
           method: 'POST',
           body: JSON.stringify({ currentPassword, newPassword }),
         });


### PR DESCRIPTION
## Summary
- normalize legacy auth register/login endpoints to lowercase trimmed emails for consistent credential checks
- route client auth flows through the secure endpoints and align the change-password call with the server path
- fix the reset-password component import so the environment config resolves correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922958595e08333b8e6b7c18bba915c)