### PR TITLE
Fix Vercel deployment: disable redundant workflows and fix Lighthouse CI

### DIFF
--- a/.github/workflows/auto-alias-production.yml
+++ b/.github/workflows/auto-alias-production.yml
@@ -1,8 +1,11 @@
-name: Auto-Alias Production Domain
+name: Auto-Alias Production Domain (Disabled)
+
+# DISABLED: This workflow is redundant - ci-cd-integrated.yml handles domain aliasing
+# The main workflow already sets aliases for literati.pro and www.literati.pro
 
 on:
-  # Trigger after successful deployment
-  deployment_status:
+  # deployment_status:  # Disabled - handled by ci-cd-integrated.yml
+  workflow_dispatch_disabled:  # Prevents manual triggering
 
 jobs:
   update-domain-aliases:

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -1,10 +1,14 @@
-name: Deploy to Vercel
+name: Deploy to Vercel (Disabled)
+
+# DISABLED: This workflow is redundant - ci-cd-integrated.yml handles Vercel deployment
+# To re-enable, change 'workflow_dispatch_disabled' back to 'workflow_dispatch'
+# and uncomment the push trigger
 
 on:
-  push:
-    branches: [ main ]
-    paths: [ 'client2/**' ]
-  workflow_dispatch:
+  # push:
+  #   branches: [ main ]
+  #   paths: [ 'client2/**' ]
+  workflow_dispatch_disabled:  # Renamed to disable manual trigger
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary
- Disable redundant `deploy-vercel.yml` workflow (was failing with `spawn sh ENOENT` error)
- Disable redundant `auto-alias-production.yml` workflow (duplicates ci-cd-integrated.yml functionality)
- Fix Lighthouse CI path configuration for consistent behavior across workflows

## Problem
Multiple workflows were competing to deploy to Vercel:
1. `ci-cd-integrated.yml` - Uses `amondnet/vercel-action` ✅ (works)
2. `deploy-vercel.yml` - Uses Vercel CLI directly ❌ (failing)
3. `auto-alias-production.yml` - Redundant domain aliasing ❌

The `deploy-vercel.yml` was failing because `vercel build` attempted to run `cd .. && pnpm install` which caused `spawn sh ENOENT`.

## Solution
- Disabled redundant workflows by commenting out triggers
- `ci-cd-integrated.yml` remains the single source of truth for:
  - Vercel deployment
  - Domain aliasing (literati.pro, www.literati.pro)

## Changes
| File | Change |
|------|--------|
| `deploy-vercel.yml` | Disabled (redundant) |
| `auto-alias-production.yml` | Disabled (redundant) |
| `client2/.lighthouserc.json` | Fixed staticDistDir path |
| `.github/workflows/test.yml` | Fixed Lighthouse action config |

## Test Plan
- [ ] CI workflows complete without deployment conflicts
- [ ] `ci-cd-integrated.yml` successfully deploys to Vercel
- [ ] Domain aliases are properly set
