### PR TITLE
Refresh dashboard hero actions and gamification feedback

### DIFF
--- a/client2/src/styles/dashboard-page.css
+++ b/client2/src/styles/dashboard-page.css
@@ -1453,6 +1453,13 @@
   font-weight: 500;
 }
 
+.welcome-purpose {
+  margin: 0;
+  color: var(--md-sys-color-on-surface-variant);
+  font-weight: 600;
+  letter-spacing: 0.2px;
+}
+
 /* Subtitle Row with Inline Buttons */
 .welcome-subtitle-row {
   display: flex;
@@ -2469,3 +2476,150 @@
 #dashboard-currently-reading .covers-scroll .book-title, #dashboard-currently-reading .covers-scroll .book-author { display: none !important; }
 
 
+.md3-filled-button,
+.md3-tonal-button,
+.md3-outlined-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 999px;
+  font-weight: 700;
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  border: none;
+  font-family: inherit;
+}
+
+.md3-filled-button {
+  background: var(--md-sys-color-primary);
+  color: var(--md-sys-color-on-primary);
+  box-shadow: var(--md-sys-elevation-level2);
+}
+
+.md3-filled-button:hover { box-shadow: var(--md-sys-elevation-level3); transform: translateY(-1px); }
+.md3-filled-button:active { transform: translateY(0); }
+
+.md3-tonal-button {
+  background: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+  box-shadow: var(--md-sys-elevation-level1);
+}
+
+.md3-tonal-button:hover { box-shadow: var(--md-sys-elevation-level2); transform: translateY(-1px); }
+.md3-tonal-button:active { transform: translateY(0); }
+
+.welcome-cta-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.progress-block-elevated {
+  margin-top: 12px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: var(--md-sys-color-surface-container-high);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  box-shadow: var(--md-sys-elevation-level3);
+}
+
+[data-theme="dark"] .progress-block-elevated {
+  background: var(--md-sys-color-surface-container-highest);
+  box-shadow: var(--md-sys-elevation-level2);
+}
+
+.badge-strip {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  gap: 8px;
+  margin-top: 10px;
+  padding-top: 6px;
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  overflow-x: auto;
+}
+
+.badge-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 12px;
+  background: var(--md-sys-color-surface-container-low);
+  color: var(--md-sys-color-on-surface);
+  font-weight: 600;
+  box-shadow: var(--md-sys-elevation-level1);
+  white-space: nowrap;
+}
+
+.goal-selector {
+  margin: 12px 0 4px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: var(--md-sys-color-surface-container-low);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  box-shadow: var(--md-sys-elevation-level1);
+}
+
+.goal-selector-header { display: flex; justify-content: space-between; align-items: center; }
+.goal-selector-label { margin: 0; font-weight: 700; color: var(--md-sys-color-on-surface); }
+.goal-selector-subtext { margin: 2px 0 0; color: var(--md-sys-color-on-surface-variant); font-size: 0.9rem; }
+
+.goal-toggle-group { display: flex; gap: 8px; margin-top: 10px; }
+.md3-segmented {
+  flex: 1;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  background: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.md3-segmented.active {
+  border-color: var(--md-sys-color-primary);
+  background: var(--md-sys-color-primary-container);
+  color: var(--md-sys-color-on-primary-container);
+  box-shadow: var(--md-sys-elevation-level2);
+}
+
+.smart-resume-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  margin: 12px 0;
+  border-radius: 18px;
+  background: var(--md-sys-color-surface-container-high);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  box-shadow: var(--md-sys-elevation-level2);
+}
+.smart-resume-meta { max-width: 70%; }
+.smart-resume-label { margin: 0; text-transform: uppercase; letter-spacing: 1px; font-size: 0.8rem; color: var(--md-sys-color-on-surface-variant); }
+.smart-resume-title { margin: 4px 0; font-size: 1.2rem; color: var(--md-sys-color-on-surface); }
+.smart-resume-author { margin: 0; color: var(--md-sys-color-on-surface-variant); }
+.smart-resume-progress { margin: 8px 0 0; color: var(--md-sys-color-primary); font-weight: 700; }
+.smart-resume-actions { display: flex; gap: 8px; align-items: center; }
+
+.points-confetti {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+  box-shadow: var(--md-sys-elevation-level3);
+  opacity: 0;
+  transform: translateY(-10px) scale(0.96);
+  transition: all 0.35s ease;
+  z-index: 9999;
+  pointer-events: none;
+}
+.points-confetti.show { opacity: 1; transform: translateY(0) scale(1); }
+.points-confetti::after {
+  content: '🎉';
+  margin-left: 6px;
+}


### PR DESCRIPTION
## Summary
- add mission-driven hero messaging with primary/secondary CTAs, elevated progress block, badge strip, and smart resume card on the dashboard
- introduce goal selector plus MD3 surface/button styling updates for dashboard interactions
- centralize gamification feedback with snackbars and micro-animations for reading sessions and notes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df1fd2938833387908594be023b45)